### PR TITLE
fix prepareCampsite to use zoneDC

### DIFF
--- a/src/camping/camping.ts
+++ b/src/camping/camping.ts
@@ -118,11 +118,11 @@ export async function tellCampfireStory(game: Game, actor: any): Promise<void> {
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 export async function prepareCampsite(game: Game, actor: any): Promise<void> {
-    const dc = getLevelBasedDC(actor.level);
+    const {zoneDC} = getRegionInfo(game);
 
     if (actor) {
         const result = await actor.skills.survival.roll({
-            dc,
+            zoneDC,
         });
         await postDegreeOfSuccessMessage(result.degreeOfSuccess, {
             critSuccess: `Prepare Campsite: ${actor.name} find the perfect spot for a camp. Flat checks to determine encounters at the campsite for the next 24 hours have a DC 2 higher than normal, and the first 2 hours spent performing Camping activities does not incur the usual flat check for random encounters.`,


### PR DESCRIPTION
Per rules: ```You spend 2 hours searching the hex for a safe and secure location to make camp and then setting up the campsite itself by attempting a Survival check against the Zone DC of the region you’re located in```